### PR TITLE
Fix RSSI Fehlermeldung nach Migration des Template Sensors

### DIFF
--- a/custom_components/maxxi_charge_connect/devices/Rssi.py
+++ b/custom_components/maxxi_charge_connect/devices/Rssi.py
@@ -1,4 +1,7 @@
-from homeassistant.components.sensor import SensorEntity
+from homeassistant.components.sensor import (
+    SensorEntity,
+    SensorStateClass,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_WEBHOOK_ID,
@@ -23,6 +26,7 @@ class Rssi(SensorEntity):
         self._attr_icon = "mdi:wifi"
         self._attr_native_value = None
         self._attr_device_class = "signal_strength"
+        self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_native_unit_of_measurement = SIGNAL_STRENGTH_DECIBELS_MILLIWATT
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
 


### PR DESCRIPTION
Der Template Sensor in der manuellen Integration hatte die "state_class" = Measurement.

Wenn man den Sensor auf den neuen RSSI Sensor migriert kommt in HA die Fehlermeldung:

"Die Entität hat keine Zustandsklasse mehr
In der Vergangenheit wurden Statistiken für „MaxxiCharge-id2 WiFi Signalstärke“ (sensor.maxxicharge1_wifi_signalstarke_dbm) generiert, es verfügt jedoch nicht mehr über eine Zustandsklasse und deshalb können hierfür keine langfristigen Statistiken mehr erstellt werden."

Die Zuordnung der state_class verhindert die Fehlermeldung und es werden auch wieder Statistikdaten für RSSI geschrieben.